### PR TITLE
Fix the CLI / bin issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "tsc",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "node scripts/postinstall.js"
   },
   "keywords": [
     "nyx",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,13 @@
+const { execSync } = require('child_process');
+const os = require('os');
+
+const platform = os.platform();
+
+if (platform === 'linux' || platform === 'darwin') {
+  execSync('chmod +x dist/cli.js');
+  console.log('Set executable permissions for dist/cli.js');
+} else if (platform === 'win32') {
+  console.log('Windows detected, no need to set executable permissions');
+} else {
+  console.log('Unknown platform, no changes made');
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,17 +1,21 @@
+#!/usr/bin/env node
+
 import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import process from "node:process";
 import { interpret } from "./interpreter";
 
-const program = new Command();
+if (require.main === module) {
+  const program = new Command();
 
-program
-  .version("1.0.0-b.1")
-  .description("Nyx Programming Language CLI")
-  .argument("<file>", "Nyx source file to execute")
-  .action((file) => {
-    const code = readFileSync(file, "utf-8");
-    interpret(code);
-  });
+  program
+    .version("1.0.0-b.1")
+    .description("Nyx Programming Language CLI")
+    .argument("<file>", "Nyx source file to execute")
+    .action((file) => {
+      const code = readFileSync(file, "utf-8");
+      interpret(code);
+    });
 
-program.parse(process.argv);
+  program.parse(process.argv);
+}


### PR DESCRIPTION
Fix the CLI command `nyx --help` to display help information instead of opening the `cli.js` file in an editor.

* **src/cli.ts**
  - Add a shebang line `#!/usr/bin/env node` at the top of the file.
  - Add a check to ensure the script is being run directly.
* **package.json**
  - Add a `postinstall` script to run a helper script to check the OS.
* **scripts/postinstall.js**
  - Create a helper script to check the OS.
  - If the OS is Linux or macOS, set the permissions for `dist/cli.js` using `chmod`.
  - If the OS is Windows, simply return a success.

